### PR TITLE
Add commands for certbot related things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__/
 servers.json
 nginx.conf
 nginx.conf.bak

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:1.21
 
 COPY nginx.conf /etc/nginx/nginx.conf
-ADD https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf /etc/letsencrypt/options-ssl-nginx.conf
+ADD https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf /etc/nginx/options-ssl-nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:1.21
 
 COPY nginx.conf /etc/nginx/nginx.conf
+ADD https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf /etc/letsencrypt/options-ssl-nginx.conf

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ generate-certs:
 	if [ -z "$$MISSING_CERTS" ]; then \
 		echo "Found no certificates to generate"; \
 	else \
-		docker-compose run certbot --service-ports certonly \
+		docker-compose run --service-ports certbot certonly \
 			--domains "$$MISSING_CERTS" \
 			--non-interactive \
 			--standalone \

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,5 @@ start:
 stop:
 	docker-compose stop
 
+generate-certs:
+	python3 generate-certs.py

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ generate-certs:
 	if [ -z "$$MISSING_CERTS" ]; then \
 		echo "Found no certificates to generate"; \
 	else \
-		docker run certbot/certbot certonly \
+		docker run -p 80:80 certbot/certbot certonly \
 			--domains "$$MISSING_CERTS" \
 			--non-interactive \
 			--standalone \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 start:
 	if [ -e nginx.conf ]; then mv nginx.conf nginx.conf.bak; fi;
 	python3 generate-conf.py
-	docker-compose up --build -d
+	docker-compose up --build --detach
 
 stop:
 	docker-compose stop
@@ -20,5 +20,9 @@ generate-certs:
 			--standalone \
 			--agree-tos \
 			--register-unsafely-without-email \
-			--dry-run ; \
+			--dry-run; \
 	fi;
+
+renew-certs:
+	docker-compose run --service-ports certbot renew \
+		--dry-run; \

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,7 @@ generate-certs:
 			--non-interactive \
 			--standalone \
 			--agree-tos \
-			--register-unsafely-without-email \
-			--dry-run; \
+			--register-unsafely-without-email; \
 	fi;
 
 renew-certs:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ generate-certs:
 	if [ -z "$$MISSING_CERTS" ]; then \
 		echo "Found no certificates to generate"; \
 	else \
-		docker run -p 80:80 certbot/certbot certonly \
+		docker-compose run certbot --service-ports certonly \
 			--domains "$$MISSING_CERTS" \
 			--non-interactive \
 			--standalone \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 start:
-	if [ -e nginx.conf ]; then mv nginx.conf nginx.conf.bak; fi;
+	if [ -e nginx.conf ]; then mv --force nginx.conf nginx.conf.bak; fi;
 	python3 generate-conf.py
 	docker-compose up --build --detach
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,5 @@ generate-certs:
 			--non-interactive \
 			--standalone \
 			--agree-tos \
-			--register-unsafely-without-email \
-			--dry-run; \
+			--register-unsafely-without-email; \
 	fi;

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,15 @@ stop:
 	docker-compose stop
 
 generate-certs:
-	python3 generate-certs.py
+	MISSING_CERTS=$$(python3 print-missing-certs.py); \
+	if [ -z "$$MISSING_CERTS" ]; then \
+		echo "Found no certificates to generate"; \
+	else \
+		docker run certbot/certbot certonly \
+			--domains "$$MISSING_CERTS" \
+			--non-interactive \
+			--standalone \
+			--agree-tos \
+			--register-unsafely-without-email \
+			--dry-run; \
+	fi;

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 start:
-	if [ -a nginx.conf ]; then mv nginx.conf nginx.conf.bak; fi;
+	if [ -e nginx.conf ]; then mv nginx.conf nginx.conf.bak; fi;
 	python3 generate-conf.py
 	docker-compose up --build -d
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ start:
 stop:
 	docker-compose stop
 
+validate-certs:
+	python3 validate-certs.py
+
 generate-certs:
 	MISSING_CERTS=$$(python3 print-missing-certs.py); \
 	if [ -z "$$MISSING_CERTS" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,6 @@ generate-certs:
 			--non-interactive \
 			--standalone \
 			--agree-tos \
-			--register-unsafely-without-email; \
+			--register-unsafely-without-email \
+			--dry-run ; \
 	fi;

--- a/cert_utils.py
+++ b/cert_utils.py
@@ -1,0 +1,18 @@
+import json
+import os
+import sys
+
+def is_https(server):
+    return server['https']
+
+def cert_missing(domain_name):
+    chain_exists = os.path.exists("/etc/letsencrypt/live/{}/fullchain.pem".format(domain_name))
+    private_exists = os.path.exists("/etc/letsencrypt/live/{}/privkey.pem".format(domain_name))
+    return not (chain_exists and private_exists)
+
+def missing_certs():
+    with open("servers.json") as f:
+        servers_input = json.loads(f.read())
+        https_servers = filter(is_https, servers_input)
+        https_server_names = map(lambda https_server: https_server['server_name'], https_servers)
+        return list(filter(cert_missing, https_server_names))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,11 @@ services:
         - "host.docker.internal:host-gateway"
     volumes:
         - /etc/letsencrypt/:/etc/letsencrypt/
-
+  certbot:
+    image: certbot/certbot
+    ports:
+      - 80:80
+    volumes:
+      - /etc/letsencrypt/:/etc/letsencrypt/
+    profiles:
+      - tools

--- a/generate-certs.py
+++ b/generate-certs.py
@@ -1,0 +1,24 @@
+import json
+import os
+import sys
+
+def is_https(server):
+    return server['https']
+
+def cert_missing(domain_name):
+    chain_exists = os.path.exists("/etc/letsencrypt/live/{}/fullchain.pem".format(domain_name))
+    private_exists = os.path.exists("/etc/letsencrypt/live/{}/privkey.pem".format(domain_name))
+    return not (chain_exists and private_exists)
+
+with open("servers.json") as f:
+    servers_input = json.loads(f.read())
+    https_servers = filter(is_https, servers_input)
+    https_server_names = map(lambda https_server: https_server['server_name'], https_servers)
+    missing_certs = list(filter(cert_missing, https_server_names))
+
+    if not missing_certs:
+        print("Found no missing certificates")
+        sys.exit(0)
+    
+    domains = ",".join(missing_certs)
+    os.system("docker run certbot/certbot certonly --domains {} --non-interactive --standalone --agree-tos --register-unsafely-without-email --dry-run".format(missing_certs))

--- a/generate-conf.py
+++ b/generate-conf.py
@@ -25,6 +25,6 @@ with open("servers.json") as f:
     new_conf = nginx_conf.replace("$$$_SERVERS_$$$", all_servers)
     print(new_conf)
 
-    out_file = open("nginx.conf", "a")
+    out_file = open("nginx.conf", "x")
     out_file.write(new_conf)
     out_file.close()

--- a/https-server.template
+++ b/https-server.template
@@ -6,7 +6,7 @@
         listen       443 ssl;
         ssl_certificate /etc/letsencrypt/live/$_SERVER_NAME_$/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/$_SERVER_NAME_$/privkey.pem;
-        include /etc/letsencrypt/options-ssl-nginx.conf;
+        include /etc/nginx/options-ssl-nginx.conf;
 
         # Redirect non-https traffic to https
         if ($scheme != "https") {

--- a/print-missing-certs.py
+++ b/print-missing-certs.py
@@ -15,10 +15,4 @@ with open("servers.json") as f:
     https_servers = filter(is_https, servers_input)
     https_server_names = map(lambda https_server: https_server['server_name'], https_servers)
     missing_certs = list(filter(cert_missing, https_server_names))
-
-    if not missing_certs:
-        print("Found no missing certificates")
-        sys.exit(0)
-    
-    domains = ",".join(missing_certs)
-    os.system("docker run certbot/certbot certonly --domains {} --non-interactive --standalone --agree-tos --register-unsafely-without-email --dry-run".format(missing_certs))
+    print(",".join(missing_certs))

--- a/print-missing-certs.py
+++ b/print-missing-certs.py
@@ -1,18 +1,3 @@
-import json
-import os
-import sys
+from cert_utils import missing_certs
 
-def is_https(server):
-    return server['https']
-
-def cert_missing(domain_name):
-    chain_exists = os.path.exists("/etc/letsencrypt/live/{}/fullchain.pem".format(domain_name))
-    private_exists = os.path.exists("/etc/letsencrypt/live/{}/privkey.pem".format(domain_name))
-    return not (chain_exists and private_exists)
-
-with open("servers.json") as f:
-    servers_input = json.loads(f.read())
-    https_servers = filter(is_https, servers_input)
-    https_server_names = map(lambda https_server: https_server['server_name'], https_servers)
-    missing_certs = list(filter(cert_missing, https_server_names))
-    print(",".join(missing_certs))
+print(",".join(missing_certs()))

--- a/validate-certs.py
+++ b/validate-certs.py
@@ -1,0 +1,9 @@
+import sys
+from cert_utils import missing_certs
+
+missing_certs = missing_certs()
+if missing_certs:
+    print("Missing certs: " + ",".join(missing_certs), file=sys.stderr)
+    sys.exit(1)
+
+sys.exit(0)


### PR DESCRIPTION
Introduce three new commands to the makefile:

**validate-certs**
Iterates the servers in `servers.json`, returns a non-zero exit status if any of the servers (with https: true) does not have `fullchain.pem` and `privkey.pem`-files in the expected locations.

**generate-certs**
Iterates the servers in `servers.json`, attempting to generate a certificate with certbot for any servers (with https: true) that does not have `fullchain.pem` and `privkey.pem`-files in the expected locations.
Reason for only attempting with servers where files does not exist is because I've previously hit the rate limit of letsencrypt while attempting to automate the flow. I want to avoid that.

**renew-certs**
Attempts to renew any certificates previously obtained with certbot.

**Other notes**:
 - Replaced `-a` flag with `-e` when checking if nginx.conf exist. As far as I understand, `-a` is deprecated (in the context of checking that a file exist) and was not recognized in the shell on my server
 - Changed expected location of `options-ssl-nginx.conf`. I did this because I wanted to include it while building the docker container, and if it was in `/etc/letsencrypt` - It was overwritten by the mounted volume
 - Replaced `-a` flag with `-x` when opening `nginx.conf` for modification. Since we move the file prior to running the script, we expect that it doesn't exist. With `-a` it will try to append to the file, while `-x` while fail if the file exist