### PR TITLE
Change behavior of generate-certs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ generate-certs:
 			--non-interactive \
 			--standalone \
 			--agree-tos \
-			--register-unsafely-without-email; \
+			--register-unsafely-without-email \
+			--dry-run;
 	fi;
 
 renew-certs:

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,7 @@ generate-certs:
 			--non-interactive \
 			--standalone \
 			--agree-tos \
-			--register-unsafely-without-email \
-			--dry-run; \
+			--register-unsafely-without-email; \
 	done \
 
 renew-certs:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ generate-certs:
 			--standalone \
 			--agree-tos \
 			--register-unsafely-without-email \
-			--dry-run;
+			--dry-run; \
 	fi;
 
 renew-certs:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ generate-certs:
 	do \
 		docker-compose run --service-ports certbot certonly \
 			--domains "$$domain" \
+			--cert-name "$$domain" \
 			--non-interactive \
 			--standalone \
 			--agree-tos \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 start:
 	if [ -e nginx.conf ]; then mv --force nginx.conf nginx.conf.bak; fi;
 	python3 generate-conf.py

--- a/Makefile
+++ b/Makefile
@@ -10,17 +10,14 @@ validate-certs:
 	python3 validate-certs.py
 
 generate-certs:
-	MISSING_CERTS=$$(python3 print-missing-certs.py); \
-	if [ -z "$$MISSING_CERTS" ]; then \
-		echo "Found no certificates to generate"; \
+	HTTPS_DOMAINS=$$(python3 print-https-certs.py); \
+	if [ -z "$$HTTPS_DOMAINS" ]; then \
+		echo "Found no domains to generate certificates for"; \
 	else \
-		docker-compose run --service-ports certbot certonly \
-			--domains "$$MISSING_CERTS" \
-			--non-interactive \
-			--standalone \
-			--agree-tos \
-			--register-unsafely-without-email \
-			--dry-run; \
+		for domain in $${HTTPS_DOMAINS//,/ }; \
+		do \
+		echo "$$domain"; \
+		done \
 	fi;
 
 renew-certs:

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,16 @@ validate-certs:
 
 generate-certs:
 	HTTPS_DOMAINS=$$(python3 print-https-certs.py); \
-	if [ -z "$$HTTPS_DOMAINS" ]; then \
-		echo "Found no domains to generate certificates for"; \
-	else \
-		for domain in $${HTTPS_DOMAINS//,/ }; \
-		do \
-		echo "$$domain"; \
-		done \
-	fi;
+	for domain in $${HTTPS_DOMAINS//,/ }; \
+	do \
+		docker-compose run --service-ports certbot certonly \
+			--domains "$$domain" \
+			--non-interactive \
+			--standalone \
+			--agree-tos \
+			--register-unsafely-without-email \
+			--dry-run; \
+	done \
 
 renew-certs:
 	docker-compose run --service-ports certbot renew

--- a/cert_utils.py
+++ b/cert_utils.py
@@ -10,16 +10,13 @@ def cert_missing(domain_name):
     private_exists = os.path.exists("/etc/letsencrypt/live/{}/privkey.pem".format(domain_name))
     return not (chain_exists and private_exists)
 
-def missing_certs():
-    with open("servers.json") as f:
-        servers_input = json.loads(f.read())
-        https_servers = filter(is_https, servers_input)
-        https_server_names = map(lambda https_server: https_server['server_name'], https_servers)
-        return list(filter(cert_missing, https_server_names))
-
-def https_certs():
+def https_domains():
     with open("servers.json") as f:
         servers_input = json.loads(f.read())
         https_servers = filter(is_https, servers_input)
         https_server_names = map(lambda https_server: https_server['server_name'], https_servers)
         return list(https_server_names)
+
+def missing_certs():
+    https_domain = https_domains()
+    return list(filter(cert_missing, https_domain))

--- a/cert_utils.py
+++ b/cert_utils.py
@@ -16,3 +16,10 @@ def missing_certs():
         https_servers = filter(is_https, servers_input)
         https_server_names = map(lambda https_server: https_server['server_name'], https_servers)
         return list(filter(cert_missing, https_server_names))
+
+def https_certs():
+    with open("servers.json") as f:
+        servers_input = json.loads(f.read())
+        https_servers = filter(is_https, servers_input)
+        https_server_names = map(lambda https_server: https_server['server_name'], https_servers)
+        return list(https_server_names)

--- a/print-https-certs.py
+++ b/print-https-certs.py
@@ -1,3 +1,3 @@
-from cert_utils import https_certs
+from cert_utils import https_domains
 
-print(",".join(https_certs()))
+print(",".join(https_domains()))

--- a/print-https-certs.py
+++ b/print-https-certs.py
@@ -1,0 +1,3 @@
+from cert_utils import https_certs
+
+print(",".join(https_certs()))

--- a/print-missing-certs.py
+++ b/print-missing-certs.py
@@ -1,3 +1,0 @@
-from cert_utils import missing_certs
-
-print(",".join(missing_certs()))


### PR DESCRIPTION
Iterate HTTPS domains and issue a separate `certbot certonly ...` request for each https domain.

While attempting to use two different domains (alamen.rdunk.net and hiveshop.rdunk.net) certbot failed when providing both domains with the `--domains` argument. I got the impression that it'd try to expand the current certificate to cover both domains. This might work if both domain names uses same top domain, but I don't think that's anything we should enforce.

Therefore, I think it makes sense to make separate requests for each domain. If one of the domains already has a certificate, it will attempt to renew it instead.

Additionally, removed the behavior of only including domain names where certificates are missing. I think the consumer can check that with `validate-certs` prior to running `generate-certs` instead.